### PR TITLE
Rename core.bs to index.bs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     - run: pip install bikeshed
     - run: bikeshed update
     - run: bikeshed spec
-    - run: mkdir out && mv core.html out/index.html
+    - run: mkdir out && mv index.html out/
     - uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/index.bs
+++ b/index.bs
@@ -4,7 +4,7 @@ Shortname: webdriver-bidi-core
 Level: 1
 Status: w3c/ED
 Group: Browser Testing and Tools Working Group
-URL: https://w3c.github.io/webdriver/webdriver-bidi/core.html
+URL: https://w3c.github.io/webdriver/webdriver-bidi/
 Editor: Browser Testing and Tools Working Group, https://www.w3.org/testing/browser/
 No Editor: true
 Abstract: Core Protocol for BiDirectional WebDriver.


### PR DESCRIPTION
This is mostly because there should be something at
https://w3c.github.io/webdriver/webdriver-bidi/, and we have only one
thing to start with.

This doesn't change the title or shortname to remove "core".